### PR TITLE
Xml bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# OS files
+.DS_Store
+
+# R and RStudio files
+*.Rproj
+.Rproj.user
+*.RDS
+*.html
+*.png
+*.tiff
+*.csv
+*.log
+*.basex
+.RData
+*_cache/*
+*.Rhistory
+*.zip
+mtdownload8300_2023.07.24_16.41/_From Snyder, Abigail C/database_basexdb 2/__MACOSX/._database_basexdb

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# gcamlandc
+GCAM land carbon module with added carbon cycling and climate feedbacks

--- a/land_utils.R
+++ b/land_utils.R
@@ -212,8 +212,6 @@ initialize_data <- function(land_alloc, params, year0, leaf_data, climate_data, 
   leaf_data0 <- leaf_data[year=={{year0}},]
   land_alloc0 <- land_alloc[year=={{year0}},]
 
-  browser()
-  
   #matching carbon density and mature age data from protected leaves to their unprotected
   #counterparts, which have no values in xmls
   params %>%

--- a/run_land_calc.R
+++ b/run_land_calc.R
@@ -7,8 +7,8 @@ library(tidyr)
 # necessary inputs: 5 gcam land xmls + 2 protected lands, gcam database (for grabbing modern land allocation data)
 # will need to set paths for each of these in code below
 
-read_data <- FALSE  # set this flag if land allocation data needs to be updated. If false, will read from saved files
-read_params <- FALSE # set this flag if land leaf parameter data needs to be updated (carbon densities, soil timescales, etc). If false, will read from saved files
+read_data <- TRUE  # set this flag if land allocation data needs to be updated. If false, will read from saved files
+read_params <- TRUE # set this flag if land leaf parameter data needs to be updated (carbon densities, soil timescales, etc). If false, will read from saved files
 protected <- TRUE # set this flag to include protected lands. If true, will read in protected lands data to replace land inputs 2 & 3
 
 year0 <- 1745
@@ -29,9 +29,9 @@ coupled= TRUE  # this refers to coupling with Hector. If true, then NBP_constrai
 if (read_data){
   # get input data from GCAM
     gcam_land_alloc <- get_gcam_land_alloc(db_name="database_basexdb",
-                                           gcam_dir= "reference",
+                                           gcam_dir= "reference/DawnDB/",
                                            scenario="Reference",
-                                           read_from_file=TRUE)
+                                           read_from_file=FALSE)
     # scenario is doing nothing when read_from_file is TRUE
     
     land_roots <- read_land_inputs_xml2(folder = "reference", protected = protected)
@@ -98,7 +98,7 @@ output <- run_all_years(outer_land_alloc2, outer_params2, ini_file,
                         rhEff=rhEff, betaEff=betaEff,
                         cCycling=ccycling, coupled=coupled)
 
-scenario_name <- "full_world_real-protected_2100"
+scenario_name <- "full_world_protected_DawnDB_2100"
 write.csv(output[["leaf_data"]],file=paste0("data/leaf_data_",scenario_name,".csv"))
 write.csv(output[["params"]],file=paste0("data/leaf_params_",scenario_name,".csv"))
 write.csv(output[["climate"]],file=paste0("data/climate_data_",scenario_name,".csv"))


### PR DESCRIPTION
Bringing in new ACS code for dealing with XML's with either:
1) No land allocation before 1975
2) No equivalent landleaf in the historical period